### PR TITLE
Replace IsOwnerOrAdmin with IsOwner

### DIFF
--- a/apps/contact/views.py
+++ b/apps/contact/views.py
@@ -16,7 +16,7 @@ from apps.contact.serializers import (
     ContactDuplicateSerializer,
 )
 from apps.contact.services import VCardImportService
-from core.permissions import IsOwnerOrAdmin
+from core.permissions import IsOwner
 from core.views import BaseAPIView, BaseListAPIView, BaseRetrieveAPIView
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class ContactListAPIView(BaseListAPIView):
     """
 
     serializer_class = ContactListSerializer
-    permission_classes = [IsOwnerOrAdmin]
+    permission_classes = [IsOwner]
     filterset_class = ContactFilter
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["first_name", "last_name", "email", "mobile_phone", "organization"]
@@ -107,7 +107,7 @@ class ContactDetailAPIView(BaseRetrieveAPIView):
     """
 
     serializer_class = ContactDetailSerializer
-    permission_classes = [IsOwnerOrAdmin]
+    permission_classes = [IsOwner]
     lookup_field = "pk"
 
     def get_queryset(self):
@@ -135,7 +135,7 @@ class ContactDuplicateListAPIView(BaseListAPIView):
     """Contact duplicate detection API using existing manager method"""
 
     serializer_class = ContactDuplicateSerializer
-    permission_classes = [IsOwnerOrAdmin]
+    permission_classes = [IsOwner]
     filterset_class = ContactDuplicateFilter
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
 

--- a/apps/finance/views.py
+++ b/apps/finance/views.py
@@ -1,11 +1,11 @@
 from apps.finance.models import UserSubscription
 from apps.finance.serializers import UserSubscriptionSerializer
-from core.permissions import IsOwnerOrAdmin
+from core.permissions import IsOwner
 from core.views import BaseCreateAPIView, BaseListAPIView
 
 
 class UserSubscriptionCreateAPIView(BaseCreateAPIView):
-    permission_classes = [IsOwnerOrAdmin]
+    permission_classes = [IsOwner]
     serializer_class = UserSubscriptionSerializer
 
     def post(self, request, *args, **kwargs):
@@ -20,7 +20,7 @@ class UserSubscriptionCreateAPIView(BaseCreateAPIView):
 
 
 class ActiveSubscriptionListAPIView(BaseListAPIView):
-    permission_classes = [IsOwnerOrAdmin]
+    permission_classes = [IsOwner]
     serializer_class = UserSubscriptionSerializer
 
     def get(self, request, *args, **kwargs):

--- a/apps/reminder/models.py
+++ b/apps/reminder/models.py
@@ -1,0 +1,95 @@
+from django.db import models
+
+from apps.finance.models import SubscriptionService
+from apps.reminder.enums import ReminderStatusChoices, ExpenseCategoryChoices
+from core.models import BaseModel
+from core.enums import CurrencyChoices, PaymentMethodChoices
+
+
+class BaseReminder(BaseModel):
+    """
+    Base model for reminders.
+    This model can be extended to create specific reminder types.
+    """
+
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    notes = models.TextField(blank=True)
+    status = models.CharField(
+        choices=ReminderStatusChoices.choices, default=ReminderStatusChoices.PENDING, max_length=35
+    )
+
+    reminder_date = models.DateTimeField(verbose_name="Reminder Date Time")
+    scheduled_at = models.DateTimeField(auto_now=False, null=True, blank=True, verbose_name="Scheduled At")
+
+    is_notified = models.BooleanField(default=False, verbose_name="Is Notified")
+    is_recurring = models.BooleanField(default=False, verbose_name="Is Recurring")
+
+    snoozed_until = models.DateTimeField(null=True, blank=True)
+    snooze_count = models.PositiveIntegerField(default=0)
+
+    def mark_as_completed(self):
+        self.status = ReminderStatusChoices.COMPLETED
+        self.save(update_fields=["status", "last_updated"])
+
+    def mark_as_snoozed(self, snooze_until: str):
+        self.snoozed_until = snooze_until
+        self.snooze_count += 1
+        self.status = ReminderStatusChoices.SNOOZED
+        self.save(update_fields=["snoozed_until", "snooze_count", "status", "last_updated"])
+
+    def mark_as_processing(self):
+        self.status = ReminderStatusChoices.PROCESSING
+        self.save(update_fields=["status", "last_updated"])
+
+    def mark_as_failed(self):
+        self.status = ReminderStatusChoices.FAILED
+        self.save(update_fields=["status", "last_updated"])
+
+    def mark_as_expired(self):
+        self.status = ReminderStatusChoices.EXPIRED
+        self.save(update_fields=["status", "last_updated"])
+
+    class Meta:
+        abstract = True
+
+
+class FinanceReminder(BaseReminder):
+    # Financial Core
+    amount = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    currency = models.CharField(max_length=3, default="TRY", choices=CurrencyChoices.choices)
+
+    # Finance Type & Category
+    finance_category = models.CharField(max_length=50, choices=ExpenseCategoryChoices.choices)
+
+    # External Relations
+    subscription = models.ForeignKey(
+        SubscriptionService, null=True, blank=True, on_delete=models.PROTECT, related_name="finance_reminders"
+    )
+
+    # Payment Details
+    payment_method = models.CharField(max_length=50, choices=PaymentMethodChoices.choices, blank=True)
+
+    # Dates & Deadlines
+    due_date = models.DateField(null=True, blank=True)
+    grace_period_days = models.PositiveIntegerField(default=0)
+    last_payment_date = models.DateField(null=True, blank=True, auto_now=False)
+    next_payment_date = models.DateField(null=True, blank=True, auto_now=False)
+
+    # Automation & Features
+    autopay_enabled = models.BooleanField(default=False)
+    send_sms_reminder = models.BooleanField(default=True)
+    send_email_reminder = models.BooleanField(default=True)
+    alert_days_before = models.PositiveIntegerField(default=3)
+
+    # Penalty & Fees
+    late_fee_amount = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True)
+    
+    # User Association
+    user = models.ForeignKey(
+        "user.User", on_delete=models.CASCADE, related_name="finance_reminders", verbose_name="User"
+    )
+
+    class Meta:
+        verbose_name = "Finance Reminder"
+        verbose_name_plural = "Finance Reminders"

--- a/apps/reminder/models.py
+++ b/apps/reminder/models.py
@@ -32,7 +32,14 @@ class BaseReminder(BaseModel):
         self.status = ReminderStatusChoices.COMPLETED
         self.save(update_fields=["status", "last_updated"])
 
-    def mark_as_snoozed(self, snooze_until: str):
+    from datetime import datetime
+
+    def mark_as_snoozed(self, snooze_until: datetime):
+        if isinstance(snooze_until, str):
+            try:
+                snooze_until = datetime.fromisoformat(snooze_until)
+            except ValueError:
+                raise ValueError("Invalid datetime format for snooze_until. Expected ISO 8601 format.")
         self.snoozed_until = snooze_until
         self.snooze_count += 1
         self.status = ReminderStatusChoices.SNOOZED

--- a/apps/user/v2/views.py
+++ b/apps/user/v2/views.py
@@ -3,7 +3,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import permissions
 
-from core.permissions import IsOwnerOrAdmin
+from core.permissions import IsOwner
 from apps.user.models import User
 from apps.user.serializers import TokenSerializer, UserSerializer, UserUpdateSerializer
 
@@ -34,7 +34,7 @@ class UserViewSet(viewsets.ModelViewSet):
         elif self.action == "list":
             permission_classes = (permissions.AllowAny,)
         elif self.action in ["update", "partial_update"]:
-            permission_classes = [IsOwnerOrAdmin]
+            permission_classes = [IsOwner]
         else:
             permission_classes = [permissions.IsAdminUser]
         return [permission() for permission in permission_classes]

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -28,3 +28,21 @@ class IsOwnerOrAdmin(permissions.BasePermission):
         except Exception as err:
             logger.exception(f"Permission check failed: {err}")
             return False
+
+
+class IsOwner(permissions.BasePermission):
+    """Custom permission to only allow owners of an object."""
+
+    def has_object_permission(self, request: Request, view, obj):
+        try:
+            user: User = request.user
+
+            if hasattr(obj, "user"):
+                return obj.user == user
+            elif hasattr(obj, "owner"):
+                return obj.owner == user
+
+            return obj == user
+        except Exception as err:
+            logger.exception(f"Permission check failed: {err}")
+            return False


### PR DESCRIPTION
Introduced a new IsOwner permission class and replaced IsOwnerOrAdmin with IsOwner in contact, finance, and user views to restrict access to object owners only. Added BaseReminder and FinanceReminder models to apps.reminder.models for handling reminder-related data and logic.